### PR TITLE
Add XMLWriter; make XMLReader handle TIND peculiarities

### DIFF
--- a/.idea/tind.iml
+++ b/.idea/tind.iml
@@ -9,9 +9,9 @@
     </content>
     <orderEntry type="jdk" jdkName="RVM: ruby-2.7.5" jdkType="RUBY_SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="actionpack (v6.1.4.4, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="actionview (v6.1.4.4, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="activesupport (v6.1.4.4, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionpack (v6.1.4.6, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionview (v6.1.4.6, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activesupport (v6.1.4.6, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="addressable (v2.8.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="amazing_print (v1.4.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.2, RVM: ruby-2.7.5) [gem]" level="application" />
@@ -32,14 +32,15 @@
     <orderEntry type="library" scope="PROVIDED" name="docile (v1.4.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="domain_name (v0.5.20190701, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="dotenv (v2.7.6, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="equivalent-xml (v0.6.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="erubi (v1.10.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="hashdiff (v1.0.1, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="http-accept (v1.7.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="http-cookie (v1.0.4, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="i18n (v1.8.11, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="i18n (v1.10.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ice_nine (v0.11.2, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="lograge (v0.11.2, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="loofah (v2.13.0, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="loofah (v2.14.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="marc (v1.1.1, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="method_source (v1.0.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="mime-types (v3.4.1, RVM: ruby-2.7.5) [gem]" level="application" />
@@ -58,25 +59,25 @@
     <orderEntry type="library" scope="PROVIDED" name="rack-test (v1.1.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rails-dom-testing (v2.0.3, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rails-html-sanitizer (v1.4.2, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="railties (v6.1.4.4, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="railties (v6.1.4.6, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.1.1, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rake (v13.0.6, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rchardet (v1.8.0, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.2.0, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.2.1, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="request_store (v1.5.1, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rest-client (v2.1.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rexml (v3.2.5, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="roo (v2.8.3, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec (v3.10.0, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.10.1, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.10.2, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.10.2, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.10.3, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec (v3.11.0, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.11.0, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.11.0, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.11.0, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.11.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop (v1.11.0, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.15.1, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.15.2, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop-rake (v0.6.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop-rspec (v2.4.0, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="ruby-marc-spec (v0.1.1, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ruby-marc-spec (v0.1.3, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ruby-prof (v0.17.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.11.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubyzip (v2.3.2, RVM: ruby-2.7.5) [gem]" level="application" />
@@ -84,7 +85,7 @@
     <orderEntry type="library" scope="PROVIDED" name="simplecov (v0.21.2, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="simplecov-html (v0.12.3, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="simplecov-rcov (v0.2.3, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="simplecov_json_formatter (v0.1.3, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov_json_formatter (v0.1.4, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="thor (v1.2.1, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="typesafe_enum (v0.3.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="tzinfo (v2.0.4, RVM: ruby-2.7.5) [gem]" level="application" />
@@ -92,7 +93,7 @@
     <orderEntry type="library" scope="PROVIDED" name="unf_ext (v0.0.8, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="unicode-display_width (v2.1.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="webmock (v3.14.0, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="zeitwerk (v2.5.3, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="zeitwerk (v2.5.4, RVM: ruby-2.7.5) [gem]" level="application" />
   </component>
   <component name="RModuleSettingsStorage">
     <LOAD_PATH number="2" string0="$MODULE_DIR$/lib" string1="$MODULE_DIR$/spec" />

--- a/berkeley_library-tind.gemspec
+++ b/berkeley_library-tind.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'ci_reporter_rspec', '~> 1.0'
   spec.add_development_dependency 'colorize', '~> 0.8'
   spec.add_development_dependency 'dotenv', '~> 2.7'
+  spec.add_development_dependency 'equivalent-xml', '~> 0.6'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'roo', '~> 2.8'
   spec.add_development_dependency 'rspec', '~> 3.10'

--- a/lib/berkeley_library/tind/marc/xml_builder.rb
+++ b/lib/berkeley_library/tind/marc/xml_builder.rb
@@ -27,8 +27,11 @@ module BerkeleyLibrary
         end
 
         def add_leader(xml)
+          leader = marc_record.leader
+          return if leader.nil? || leader == ''
+
           # TIND uses <controlfield tag="000"/> instead of <leader/>
-          leader_as_cf = ::MARC::ControlField.new('000', clean_leader(marc_record.leader))
+          leader_as_cf = ::MARC::ControlField.new('000', clean_leader(leader))
           add_control_field(xml, leader_as_cf)
         end
 

--- a/lib/berkeley_library/tind/marc/xml_builder.rb
+++ b/lib/berkeley_library/tind/marc/xml_builder.rb
@@ -1,0 +1,59 @@
+require 'nokogiri'
+
+module BerkeleyLibrary
+  module TIND
+    module MARC
+      class XMLBuilder
+        attr_reader :marc_record
+
+        def initialize(marc_record)
+          @marc_record = marc_record
+        end
+
+        def build
+          builder.doc.root.tap(&:unlink)
+        end
+
+        private
+
+        def builder
+          Nokogiri::XML::Builder.new do |xml|
+            xml.record do
+              add_leader(xml)
+              marc_record.each_control_field { |cf| add_control_field(xml, cf) }
+              marc_record.each_data_field { |df| add_data_field(xml, df) }
+            end
+          end
+        end
+
+        def add_leader(xml)
+          # TIND uses <controlfield tag="000"/> instead of <leader/>
+          leader_as_cf = ::MARC::ControlField.new('000', clean_leader(marc_record.leader))
+          add_control_field(xml, leader_as_cf)
+        end
+
+        def add_data_field(xml, df)
+          xml.datafield(tag: df.tag, ind1: df.indicator1, ind2: df.indicator2) do
+            df.subfields.each do |sf|
+              xml.subfield(sf.value, code: sf.code)
+            end
+          end
+        end
+
+        def add_control_field(xml, cf)
+          # TIND uses \ (0x5c), not space (0x32), for unspecified values in positional fields
+          value = cf.value&.gsub(' ', '\\')
+          xml.controlfield(value, tag: cf.tag)
+        end
+
+        def clean_leader(leader)
+          leader.gsub(/[^\w|^\s]/, 'Z').tap do |ldr|
+            ldr[20..23] = '4500' unless ldr[20..23] == '4500'
+            ldr[6..6] = 'Z' if ldr[6..6] == ' '
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/berkeley_library/tind/marc/xml_writer.rb
+++ b/lib/berkeley_library/tind/marc/xml_writer.rb
@@ -1,0 +1,152 @@
+require 'nokogiri'
+require 'marc_extensions'
+require 'berkeley_library/tind/marc/xml_builder'
+
+module BerkeleyLibrary
+  module TIND
+    module MARC
+      class XMLWriter
+        include BerkeleyLibrary::Util::Files
+        include BerkeleyLibrary::Logging
+
+        # ------------------------------------------------------------
+        # Constants
+
+        UTF_8 = Encoding::UTF_8.name
+
+        EMPTY_COLLECTION_DOC = Nokogiri::XML::Builder.new(encoding: UTF_8) do |xml|
+          xml.collection(xmlns: ::MARC::MARC_NS)
+        end.doc.freeze
+
+        COLLECTION_CLOSING_TAG = '</collection>'.freeze
+
+        DEFAULT_NOKOGIRI_OPTS = { encoding: UTF_8 }.freeze
+
+        # ------------------------------------------------------------
+        # Fields
+
+        attr_reader :out
+        attr_reader :nokogiri_options
+
+        # ------------------------------------------------------------
+        # Initializer
+
+        # Initializes a new {XMLWriter}.
+        #
+        # ```ruby
+        # File.open('marc.xml', 'wb') do |f|
+        #   w = XMLWriter.new(f)
+        #   marc_records.each { |r| w.write(r) }
+        #   w.close
+        # end
+        # ```
+        #
+        # @param out [IO, String] an IO, or the name of a file
+        # @param nokogiri_options [Hash] Options passed to
+        #   {https://nokogiri.org/rdoc/Nokogiri/XML/Node.html#method-i-write_to Nokogiri::XML::Node#write_to}
+        #   Note that the `encoding` option is ignored, except insofar as
+        #   passing an encoding other than UTF-8 will raise an `ArgumentError`.
+        # @raise ArgumentError if `out` is not an IO or a string, or is a string referencing
+        #   a file path that cannot be opened for writing; or if an encoding other than UTF-8
+        #   is specified in `nokogiri-options`
+        # @see #open
+        def initialize(out, **nokogiri_options)
+          @nokogiri_options = valid_nokogiri_options(nokogiri_options)
+          @out = ensure_io(out)
+        end
+
+        # ------------------------------------------------------------
+        # Class methods
+
+        class << self
+
+          # Opens a new {XMLWriter} with the specified output destination and
+          # Nokogiri options, writes the XML prolog and opening `<collection>`
+          # tag, yields the writer to write one or more MARC records, and closes
+          # the writer.
+          #
+          # ```ruby
+          # XMLWriter.open('marc.xml') do |w|
+          #   marc_records.each { |r| w.write(r) }
+          # end
+          # ```
+          #
+          # Note that unlike initializing a writer with {#new} and closing it
+          # immediately, this will write an XML document with an empty
+          # `<collection></collection>` tag even if no records are written.
+          #
+          # @yieldparam writer [XMLWriter] the writer
+          # @see #new
+          # @see #close
+          def open(out, **nokogiri_options)
+            writer = new(out, **nokogiri_options)
+            writer.send(:ensure_open!)
+            yield writer if block_given?
+            writer.close
+          end
+        end
+
+        # ------------------------------------------------------------
+        # Instance methods
+
+        # Writes the specified record to the underlying stream, writing the
+        # XML prolog and opening `<collection>` tag if they have not yet
+        # been written.
+        #
+        # @param record [::MARC::Record] the MARC record to write.
+        # @raise IOError if the underlying stream has already been closed.
+        def write(record)
+          ensure_open!
+          record_element = XMLBuilder.new(record).build
+          record_element.write_to(out, nokogiri_options)
+          out.write("\n")
+        end
+
+        # Closes the underlying stream. If the XML prolog and opening `<collection>`
+        # tag have already been written, the closing `<collection/>` tag is written
+        # first.
+        def close
+          out.write(COLLECTION_CLOSING_TAG) if @open
+          out.close
+        end
+
+        # ------------------------------------------------------------
+        # Private
+
+        private
+
+        def ensure_open!
+          return if @open
+
+          out.write(prolog_and_opening_tag)
+          @open = true
+        end
+
+        def prolog_and_opening_tag
+          StringIO.open do |tmp|
+            EMPTY_COLLECTION_DOC.write_to(tmp, nokogiri_options)
+            result = tmp.string
+            result.sub!(%r{/>\s*$}, ">\n")
+            result
+          end
+        end
+
+        def ensure_io(file)
+          return file if writer_like?(file)
+          return File.open(file, 'wb') if parent_exists?(file)
+
+          raise ArgumentError, "Don't know how to write XML to #{file.inspect}: not an IO or file path"
+        end
+
+        def valid_nokogiri_options(opts)
+          if (encoding = opts.delete(:encoding)) && encoding != UTF_8
+            raise ArgumentError, "#{self.class.name} only supports #{UTF_8}; unable to use specified encoding #{encoding}"
+          end
+
+          DEFAULT_NOKOGIRI_OPTS.merge(opts)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/berkeley_library/util/files.rb
+++ b/lib/berkeley_library/util/files.rb
@@ -1,0 +1,29 @@
+module BerkeleyLibrary
+  module Util
+    # TODO: Move this to `berkeley_library-util`
+    module Files
+      class << self
+        include Files
+      end
+
+      def file_exists?(path)
+        (path.respond_to?(:exist?) && path.exist?) ||
+          (path.respond_to?(:to_str) && File.exist?(path))
+      end
+
+      def parent_exists?(path)
+        path.respond_to?(:parent) && path.parent.exist? ||
+          path.respond_to?(:to_str) && Pathname.new(path).parent.exist?
+      end
+
+      # Returns true if `obj` is close enough to an IO object for Nokogiri
+      # to parse as one.
+      #
+      # @param obj [Object] the object that might be an IO
+      # @see https://github.com/sparklemotion/nokogiri/blob/v1.11.1/lib/nokogiri/xml/sax/parser.rb#L81 Nokogiri::XML::SAX::Parser#parse
+      def reader_like?(obj)
+        obj.respond_to?(:read) && obj.respond_to?(:close)
+      end
+    end
+  end
+end

--- a/lib/berkeley_library/util/files.rb
+++ b/lib/berkeley_library/util/files.rb
@@ -24,6 +24,16 @@ module BerkeleyLibrary
       def reader_like?(obj)
         obj.respond_to?(:read) && obj.respond_to?(:close)
       end
+
+      # Returns true if `obj` is close enough to an IO object for Nokogiri
+      # to write to.
+      #
+      # @param obj [Object] the object that might be an IO
+      def writer_like?(obj)
+        # TODO: is it possible/desirable to loosen this? how strict is libxml2?
+        obj.is_a?(IO) || obj.is_a?(StringIO)
+      end
+
     end
   end
 end

--- a/spec/berkeley_library/tind/marc/xml_reader_spec.rb
+++ b/spec/berkeley_library/tind/marc/xml_reader_spec.rb
@@ -106,6 +106,28 @@ module BerkeleyLibrary
           end
         end
 
+        describe 'TIND peculiarities' do
+          attr_reader :record
+
+          before(:each) do
+            reader = XMLReader.new('spec/data/new-records.xml')
+            records = reader.to_a
+            expect(records.size).to eq(1) # just to be sure
+            @record = records.first
+          end
+
+          it 'converts backslashes in control fields to spaces' do
+            cf_008 = record['008']
+            expect(cf_008).to be_a(::MARC::ControlField)
+            expect(cf_008.value).to eq('190409s2015    xx                  eng  ')
+          end
+
+          it 'parses CF 000 as the leader' do
+            expect(record.leader).to eq('00287cam a2200313   4500')
+            expect(record['000']).to be_nil
+          end
+        end
+
       end
     end
   end

--- a/spec/berkeley_library/tind/marc/xml_writer_spec.rb
+++ b/spec/berkeley_library/tind/marc/xml_writer_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+require 'equivalent-xml'
+
+module BerkeleyLibrary
+  module TIND
+    module MARC
+      describe XMLWriter do
+        let(:input_path) { 'spec/data/new-records.xml' }
+        attr_reader :record
+
+        before(:each) do
+          reader = XMLReader.new(input_path)
+          @record = reader.first
+        end
+
+        describe :open do
+
+          it 'writes a MARC record to a file as XML' do
+            Dir.mktmpdir(File.basename(__FILE__, '.rb')) do |dir|
+              output_path = File.join(dir, 'marc.xml')
+              XMLWriter.open(output_path) { |w| w.write(record) }
+
+              expected = File.open(input_path) { |f| Nokogiri::XML(f) }
+              actual = File.open(output_path) { |f| Nokogiri::XML(f) }
+
+              aggregate_failures do
+                EquivalentXml.equivalent?(expected, actual) do |n1, n2, result|
+                  expect(n2.to_s).to eq(n1.to_s) unless result
+                end
+              end
+            end
+          end
+
+          it 'writes a MARC record to a StringIO' do
+            out = StringIO.new
+            XMLWriter.open(out) { |w| w.write(record) }
+            expected = File.open(input_path) { |f| Nokogiri::XML(f) }
+            actual = Nokogiri::XML(out.string)
+            aggregate_failures do
+              EquivalentXml.equivalent?(expected, actual) do |n1, n2, result|
+                expect(n2.to_s).to eq(n1.to_s) unless result
+              end
+            end
+          end
+
+          it 'accepts Nokogiri options' do
+            Dir.mktmpdir(File.basename(__FILE__, '.rb')) do |dir|
+              expected_path = File.join(dir, 'expected.xml')
+              XMLWriter.open(expected_path) { |w| w.write(record) }
+
+              actual_path = File.join(dir, 'actual.xml')
+              XMLWriter.open(actual_path, indent_text: "\t") { |w| w.write(record) }
+
+              expected = File.read(expected_path).gsub(%r{ (?= *<)(?!/)}, "\t")
+              actual = File.read(actual_path)
+              expect(actual).to eq(expected)
+            end
+          end
+
+          it 'accepts an explicit UTF-8 argument' do
+            Dir.mktmpdir(File.basename(__FILE__, '.rb')) do |dir|
+              output_path = File.join(dir, 'marc.xml')
+              XMLWriter.open(output_path, encoding: 'UTF-8') { |w| w.write(record) }
+
+              expected = File.open(input_path) { |f| Nokogiri::XML(f) }
+              actual = File.open(output_path) { |f| Nokogiri::XML(f) }
+
+              aggregate_failures do
+                EquivalentXml.equivalent?(expected, actual) do |n1, n2, result|
+                  expect(n2.to_s).to eq(n1.to_s) unless result
+                end
+              end
+            end
+          end
+
+          it 'only writes UTF-8' do
+            Dir.mktmpdir(File.basename(__FILE__, '.rb')) do |dir|
+              output_path = File.join(dir, 'marc.xml')
+              expect { XMLWriter.open(output_path, encoding: 'UTF-16') }.to raise_error(ArgumentError)
+              expect(File.exist?(output_path)).to eq(false)
+            end
+          end
+
+          it 'rejects an invalid file path' do
+            bad_directory = Dir.mktmpdir(File.basename(__FILE__, '.rb')) { |dir| dir }
+            expect(File.directory?(bad_directory)).to eq(false)
+            output_path = File.join(bad_directory, 'marc.xml')
+            expect { XMLWriter.open(output_path) }.to raise_error(ArgumentError)
+          end
+
+          it 'rejects a non-IO, non-String argument' do
+            invalid_target = Object.new
+            expect { XMLWriter.open(invalid_target) }.to raise_error(ArgumentError)
+          end
+        end
+
+        describe :close do
+          it 'closes without writing the closing tag if nothing has been written' do
+            Dir.mktmpdir(File.basename(__FILE__, '.rb')) do |dir|
+              output_path = File.join(dir, 'marc.xml')
+              w = XMLWriter.new(output_path)
+              w.close
+
+              stat = File.stat(output_path)
+              expect(stat.size).to eq(0)
+            end
+          end
+
+          it 'writes the closing tag if the opening tag has been written' do
+            Dir.mktmpdir(File.basename(__FILE__, '.rb')) do |dir|
+              output_path = File.join(dir, 'marc.xml')
+              XMLWriter.open(output_path)
+              expect(File.exist?(output_path)).to eq(true)
+
+              doc = File.open(output_path) { |f| Nokogiri::XML(f) }
+              expect(doc.root.name).to eq('collection')
+            end
+          end
+        end
+
+        describe :write do
+          it 'raises an IOError if the writer has already been closed' do
+            Dir.mktmpdir(File.basename(__FILE__, '.rb')) do |dir|
+              output_path = File.join(dir, 'marc.xml')
+              w = XMLWriter.new(output_path)
+              w.close
+
+              expect { w.write(record) }.to raise_error(IOError)
+
+              stat = File.stat(output_path)
+              expect(stat.size).to eq(0)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/berkeley_library/tind/marc/xml_writer_spec.rb
+++ b/spec/berkeley_library/tind/marc/xml_writer_spec.rb
@@ -131,6 +131,24 @@ module BerkeleyLibrary
               expect(stat.size).to eq(0)
             end
           end
+
+          it 'does not write a nil leader' do
+            record.leader = nil
+            marc_xml = StringIO.open do |out|
+              XMLWriter.open(out) { |w| w.write(record) }
+              out.string
+            end
+            expect(marc_xml).not_to include('leader')
+          end
+
+          it 'does not write a blank leader' do
+            record.leader = ''
+            marc_xml = StringIO.open do |out|
+              XMLWriter.open(out) { |w| w.write(record) }
+              out.string
+            end
+            expect(marc_xml).not_to include('leader')
+          end
         end
       end
     end

--- a/spec/data/new-records.xml
+++ b/spec/data/new-records.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  Source: "Batch Uploader: Caveats, common errors and example metadata files", docs.tind.io
+-->
 <collection xmlns="http://www.loc.gov/MARC21/slim">
   <record>
 

--- a/spec/data/new-records.xml
+++ b/spec/data/new-records.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+
+    <!-- The Leader is encoded in the `000` control field.
+	 If you want to edit the leader in software such as
+	 MarcEdit, you will need to change these fields to a
+	 leader tag. Then, before import into the repository
+	 you will need to change the fields back to controlfields
+	 with tag `000`.
+    -->
+    <controlfield tag="000">00287cam\a2200313\\\4500</controlfield>
+
+    <!-- All whitespace in control fields need to be replaced with
+	 backspaces.
+    -->
+    <controlfield tag="008">190409s2015\\\\xx\\\\\\\\\\\\\\\\\\eng\\</controlfield>
+
+    <!-- Regular fields are encoded in datafield elements. -->
+    <datafield tag="100" ind1="0" ind2=" ">
+      <subfield code="a">Aristotle</subfield>
+      <subfield code="0">580897</subfield>
+    </datafield>
+    
+    <datafield tag="245" ind1="0" ind2="0">
+      <subfield code="a">Metaphysics</subfield>
+      <subfield code="c">Aristotle</subfield>
+    </datafield>
+    
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="a">Narnia</subfield>
+      <subfield code="b">Fictive Books</subfield>
+      <subfield code="c">2015</subfield>
+    </datafield>
+
+    <!-- Make sure to include a collection when uploading new
+	 records, so that the record will be searchable.
+    -->
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">BIB</subfield>
+    </datafield>
+  </record>
+</collection>


### PR DESCRIPTION
## XMLWriter

Adds a class `BerkeleyLibrary::TIND::MARC::XMLWriter` to write MARCXML in the format expected by the TIND batch uploader:

- MARC leader is written to control field `000` as required by TIND
- control fields (including the leader) use `\` (0x5c), not space (0x32), for unspecified positional values

```ruby
XMLWriter.open('marc.xml') do |w|
  marc_records.each { |r| w.write(r) }
end
```

Example output:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<collection xmlns="http://www.loc.gov/MARC21/slim">
<record>
  <controlfield tag="000">00287cam\a2200313\\\4500</controlfield>
  <controlfield tag="008">190409s2015\\\\xx\\\\\\\\\\\\\\\\\\eng\\</controlfield>
  <datafield tag="100" ind1="0" ind2=" ">
    <subfield code="a">Aristotle</subfield>
    <subfield code="0">580897</subfield>
  </datafield>
  <datafield tag="245" ind1="0" ind2="0">
    <subfield code="a">Metaphysics</subfield>
    <subfield code="c">Aristotle</subfield>
  </datafield>
  <datafield tag="260" ind1=" " ind2=" ">
    <subfield code="a">Narnia</subfield>
    <subfield code="b">Fictive Books</subfield>
    <subfield code="c">2015</subfield>
  </datafield>
  <datafield tag="980" ind1=" " ind2=" ">
    <subfield code="a">BIB</subfield>
  </datafield>
</record>
</collection>
```

Note that this is a complete Nokogiri-based re-implementation of ruby-marc's [MARC::XMLWriter](https://www.rubydoc.info/gems/marc/1.0.0/MARC/XMLWriter) -- we already require Nokogiri, and ruby-marc's REXML-based writer implementation, with one giant [`encode`](https://github.com/ruby-marc/ruby-marc/blob/v1.1.1/lib/marc/xmlwriter.rb#L62-L154) method, turns out to be difficult to extend to handle TIND's peculiarities.

Fixes #1.

## XMLReader improvements

`BerkeleyLibrary::TIND::MARC::XMLReader` now handles the same TIND peculiarities mentioned above, reversing them -- control field `000` is read into the leader of the MARC record, and slashes in control field values (including the leader) are replaced with spaces.