### PR TITLE
0.6.0 release candidate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,21 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - run: bundle exec rake
+
+      - name: Run checks
+        run: bundle exec rake
+
+      - name: Upload artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: artifacts/**

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -36,6 +36,7 @@
     <inspection_tool class="RubyMismatchedVariableType" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="myCheckNilability" value="false" />
     </inspection_tool>
+    <inspection_tool class="RubyNilAnalysis" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="RubyParameterNamingConvention" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="RubyStringKeysInHashInspection" enabled="true" level="INFORMATION" enabled_by_default="true" />
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -10,6 +10,14 @@
     <inspection_tool class="LanguageDetectionInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Rubocop" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RubyCaseWithoutElseBlockInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RubyClassMethodNamingConvention" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="RubyClassModuleNamingConvention" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="RubyClassVariableNamingConvention" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="RubyConstantNamingConvention" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="RubyGlobalVariableNamingConvention" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="RubyInstanceMethodNamingConvention" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="RubyInstanceVariableNamingConvention" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="RubyLocalVariableNamingConvention" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="RubyMismatchedArgumentType" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="myCheckNilability" value="false" />
     </inspection_tool>
@@ -28,6 +36,7 @@
     <inspection_tool class="RubyMismatchedVariableType" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="myCheckNilability" value="false" />
     </inspection_tool>
+    <inspection_tool class="RubyParameterNamingConvention" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="RubyStringKeysInHashInspection" enabled="true" level="INFORMATION" enabled_by_default="true" />
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="true" />

--- a/.idea/tind.iml
+++ b/.idea/tind.iml
@@ -15,6 +15,7 @@
     <orderEntry type="library" scope="PROVIDED" name="addressable (v2.8.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="amazing_print (v1.4.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.2, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="berkeley_library-alma (v0.0.4, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="berkeley_library-logging (v0.2.6, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="berkeley_library-marc (v0.3.1, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="berkeley_library-util (v0.1.1, RVM: ruby-2.7.5) [gem]" level="application" />
@@ -39,7 +40,7 @@
     <orderEntry type="library" scope="PROVIDED" name="http-cookie (v1.0.4, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="i18n (v1.10.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ice_nine (v0.11.2, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="lograge (v0.11.2, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="lograge (v0.12.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="loofah (v2.15.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="marc (v1.1.1, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="method_source (v1.0.0, RVM: ruby-2.7.5) [gem]" level="application" />
@@ -110,7 +111,7 @@
           </RakeTaskImpl>
           <RakeTaskImpl description="Run all specs in spec directory, with coverage" fullCommand="coverage" id="coverage" />
           <RakeTaskImpl description="Run tests, check test coverage, check code style, check for vulnerabilities, build gem" fullCommand="default" id="default" />
-          <RakeTaskImpl description="Build berkeley_library-tind.gemspec as berkeley_library-tind-0.4.3.gem" fullCommand="gem" id="gem" />
+          <RakeTaskImpl description="Build berkeley_library-tind.gemspec as berkeley_library-tind-0.6.0.gem" fullCommand="gem" id="gem" />
           <RakeTaskImpl description="Run RuboCop with auto-correct, and output results to console" fullCommand="ra" id="ra" />
           <RakeTaskImpl description="Run rubocop with HTML output" fullCommand="rubocop" id="rubocop" />
           <RakeTaskImpl id="rubocop">

--- a/.idea/tind.iml
+++ b/.idea/tind.iml
@@ -48,7 +48,7 @@
     <orderEntry type="library" scope="PROVIDED" name="mime-types-data (v3.2022.0105, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="minitest (v5.15.0, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="netrc (v0.11.0, RVM: ruby-2.7.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="nokogiri (v1.13.1, RVM: ruby-2.7.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="nokogiri (v1.13.3, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="oj (v3.13.11, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ougai (v1.9.1, RVM: ruby-2.7.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="parallel (v1.21.0, RVM: ruby-2.7.5) [gem]" level="application" />

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # 0.6.0 (next)
 
 - Adds `BerkeleyLibrary::TIND::Mapping` module to map MARC records from Alma to TIND.
+- `BerkeleyLibrary::TIND::MARC::XMLWriter` now assumes that any object that response to `:write`
+  and `:close` is suffiently `IO`-like to write to.
 
 # 0.5.1 (2023-03-23)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# 0.6.0 (next)
+# 0.6.0 (2023-04-06)
 
 - Adds `BerkeleyLibrary::TIND::Mapping` module to map MARC records from Alma to TIND.
 - `BerkeleyLibrary::TIND::MARC::XMLWriter` now assumes that any object that response to `:write`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.6.0 (next)
+
+- Adds `BerkeleyLibrary::TIND::Mapping` module to map MARC records from Alma to TIND.
+
 # 0.5.1 (2023-03-23)
 
 - Fix an issue where `BerkeleyLibrary::TIND::MARC::XMLWriter` would drop fields with nonstandard tags (e.g. `FFT` fields)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ application configuration (`Rails.application.config`).
 object, but will always be returned as a `URI` object, and an invalid
 string setting will raise `URI::InvalidURIError`.
 
+### Alma configuration
+
+When mapping Alma records to TIND (see below), this gem uses 
+[`berkeley_library-alma`](https://github.com/BerkeleyLibrary/alma) to load
+Alma records. The scripts in the `bin` directory use the default Alma
+configuration; see the `berkeley_library-alma` 
+[README](https://github.com/BerkeleyLibrary/alma#configuration) for
+details.
+
 ## Command-line tool: `tind-export`
 
 The `tind-export` command allows you to list TIND collections, or to
@@ -86,12 +95,10 @@ the TIND base URL and API key either via the environment, as above, or as option
 passed to the `tind-export` command. If both an explicit option and an environment
 variable are set for either, the explicit option takes precedence.
 
-
-
-
-## Transforming TIND Record
+## Mapping MARC records from Alma to TIND
 
 ### Transforming Class:
+
 1. BerkeleyLibrary::TIND::Mapping::AlmaSingleTIND    (Transforming one Alma record => One TIND record)
 2. BerkeleyLibrary::TIND::Mapping::AlmaMultipleTIND  (Transforming one Alma record => Multiple TIND records)
 
@@ -110,14 +117,12 @@ variable are set for either, the explicit option takes precedence.
     - 901$m
     - 85641$u,$y
 
-3. Added at the time of transforming TIND record (fields of a collection or it's record)
+3. Added at the time of transforming TIND record (fields of a collection or its record)
 
     - FFT
     - 035$a
     - 998$a
     - ...
-
-
 
 ### Example
 
@@ -183,20 +188,19 @@ id = 'C084093187'
 
 alma_tind = BerkeleyLibrary::TIND::Mapping::AlmaSingleTIND.new
 tind_record = alma_tind.record(id, additional_tind_fields_1)
-
 ```
 
 
 4. Or transforming one Alma record => Multiple TIND records
+
 ``` ruby
 setup_collection
 
-# id can be  1)mms_id;  2)Millennium no ; or 3)Barcode
+# id can be 1) mms_id; 2) Millennium bib number; or 3) Item barcode
 # id = '991085821143406532'
 id = 'C084093187'
 
 alma_tind = BerkeleyLibrary::TIND::Mapping::AlmaMultipleTIND.new(id)
 tind_record_1 = alma_tind.record(additional_tind_fields_1)
 tind_record_2 = alma_tind.record(additional_tind_fields_2)
-
 ```

--- a/bin/alma-multiple-tind
+++ b/bin/alma-multiple-tind
@@ -44,6 +44,7 @@ alma_id = '991085821143406532'
 
 setup
 
+BerkeleyLibrary::Alma::Config.default!
 alma_multiple_tind = BerkeleyLibrary::TIND::Mapping::AlmaMultipleTIND.new(alma_id)
 tind_record = alma_multiple_tind.record(additional_tind_fields)
 alma_multiple_tind.save_tind_record_to_file(tind_record, 'tmp/multiple.xml')

--- a/bin/alma-single-tind
+++ b/bin/alma-single-tind
@@ -33,15 +33,16 @@ def additional_tind_fields
   [fft] << f
 end
 
-############## Use this, when crate a TIND record from each Alma record ############
+############## Use this, when creating a TIND record from each Alma record ############
 # alma_id = '991085821143406532'
 # alma_id_bad = '99108582114340653' # a bad alma_id
-# alma_id_not_qualified = '991084606989706532' # Host histrical record
+# alma_id_not_qualified = '991084606989706532' # Host historical record
 barcode = 'C084093187'
 
 id = barcode
 setup
 
+BerkeleyLibrary::Alma::Config.default!
 alma_single_tind = BerkeleyLibrary::TIND::Mapping::AlmaSingleTIND.new
 tind_record = alma_single_tind.record(id, additional_tind_fields)
 alma_single_tind.save_tind_record_to_file(id, tind_record, 'tmp/test_single.xml')

--- a/bin/alma-single-tind
+++ b/bin/alma-single-tind
@@ -22,7 +22,7 @@ def setup
     '991' => []
   }
   BerkeleyLibrary::TIND::Mapping::AlmaBase.is_035_from_mms_id = true
-  BerkeleyLibrary::TIND::Mapping::AlmaBase.is_barcode = true
+  BerkeleyLibrary::TIND::Mapping::AlmaBase.is_barcode = false
 end
 
 def additional_tind_fields

--- a/bin/tind-marc
+++ b/bin/tind-marc
@@ -39,7 +39,7 @@ collection_tind_fields = BerkeleyLibrary::TIND::Mapping::ExternalTindField.tind_
 
 # 3. get other external tind fields
 other_external_tind_fields = []
-tind_fields_from_alma_id = BerkeleyLibrary::TIND::Mapping::ExternalTindField.tind_fields_from_alma_id('991011084939706532')
+tind_fields_from_alma_id = BerkeleyLibrary::TIND::Mapping::ExternalTindField.tind_mms_id_fields('991011084939706532')
 
 other_external_tind_fields.concat tind_fields_from_alma_id
 

--- a/lib/berkeley_library/tind/mapping/alma_base.rb
+++ b/lib/berkeley_library/tind/mapping/alma_base.rb
@@ -35,8 +35,8 @@ module BerkeleyLibrary
           return logger.warn("#{id} has no TIND record or not a qualified TIND record.") unless tind_record
 
           # tind_record.leader = nil
-          # writer = BerkeleyLibrary::TIND::MARC::XMLWriter.new(file)
-          writer = ::MARC::XMLWriter.new(file)
+          writer = BerkeleyLibrary::TIND::MARC::XMLWriter.new(file)
+          # writer = ::MARC::XMLWriter.new(file)
           writer.write(tind_record)
           writer.close
         end
@@ -99,7 +99,7 @@ module BerkeleyLibrary
         end
 
         def add_f_035(mms_id, hash)
-          return nil unless AlmaBase.is_035_from_mms_id
+          return nil unless mms_id && AlmaBase.is_035_from_mms_id
 
           val_980 = hash['980'][0].strip
           TindField.f_035_from_alma_id(mms_id, val_980)

--- a/lib/berkeley_library/tind/mapping/alma_base.rb
+++ b/lib/berkeley_library/tind/mapping/alma_base.rb
@@ -68,14 +68,14 @@ module BerkeleyLibrary
           AlmaBase.is_barcode ? BerkeleyLibrary::Alma::BarCode.new(id) : BerkeleyLibrary::Alma::RecordId.parse(id)
         end
 
-        def derived_tind_fields(mms_id, id)
+        def derived_tind_fields(mms_id)
           tind_fields = []
           tind_fields << TindField.f_902_d
 
           hash = AlmaBase.collection_parameter_hash
           tind_fields.concat ExternalTindField.tind_fields_from_collection_information(hash)
 
-          tind_fields.concat ExternalTindField.tind_fields_from_alma_id(mms_id, id)
+          tind_fields.concat ExternalTindField.tind_mms_id_fields(mms_id)
 
           f_035 = add_f_035(mms_id, hash)
           tind_fields << f_035 if f_035
@@ -87,7 +87,9 @@ module BerkeleyLibrary
           tindmarc = TindMarc.new(marc_record)
           # get all derived tind_fields: 1) from collection information; 2) from id
           mms_id = tindmarc.field_catalog.mms_id
-          tind_fields = derived_tind_fields(mms_id, id)
+          logger.warn("#{id} has no Control Field 001") unless mms_id
+
+          tind_fields = derived_tind_fields(mms_id)
           # add inputted record specific datafields
           tind_fields.concat datafields
           tindmarc.tind_external_datafields = tind_fields

--- a/lib/berkeley_library/tind/mapping/alma_base.rb
+++ b/lib/berkeley_library/tind/mapping/alma_base.rb
@@ -72,10 +72,10 @@ module BerkeleyLibrary
           tind_fields = []
           tind_fields << TindField.f_902_d
 
-          hash = BerkeleyLibrary::TIND::Mapping::AlmaBase.collection_parameter_hash
-          tind_fields.concat BerkeleyLibrary::TIND::Mapping::ExternalTindField.tind_fields_from_collection_information(hash)
+          hash = AlmaBase.collection_parameter_hash
+          tind_fields.concat ExternalTindField.tind_fields_from_collection_information(hash)
 
-          tind_fields.concat BerkeleyLibrary::TIND::Mapping::ExternalTindField.tind_fields_from_alma_id(mms_id, id)
+          tind_fields.concat ExternalTindField.tind_fields_from_alma_id(mms_id, id)
 
           f_035 = add_f_035(mms_id, hash)
           tind_fields << f_035 if f_035
@@ -84,7 +84,7 @@ module BerkeleyLibrary
         end
 
         def tind_record(id, marc_record, datafields)
-          tindmarc = BerkeleyLibrary::TIND::Mapping::TindMarc.new(marc_record)
+          tindmarc = TindMarc.new(marc_record)
           # get all derived tind_fields: 1) from collection information; 2) from id
           mms_id = tindmarc.field_catalog.mms_id
           tind_fields = derived_tind_fields(mms_id, id)

--- a/lib/berkeley_library/tind/mapping/alma_base.rb
+++ b/lib/berkeley_library/tind/mapping/alma_base.rb
@@ -60,7 +60,6 @@ module BerkeleyLibrary
         end
 
         def alma_record_from(id)
-          BerkeleyLibrary::Alma::Config.default!
           record_id = get_record_id(id)
           record_id.get_marc_record
         end

--- a/lib/berkeley_library/tind/mapping/alma_base.rb
+++ b/lib/berkeley_library/tind/mapping/alma_base.rb
@@ -34,11 +34,9 @@ module BerkeleyLibrary
         def base_save(id, tind_record, file)
           return logger.warn("#{id} has no TIND record or not a qualified TIND record.") unless tind_record
 
-          # tind_record.leader = nil
-          writer = BerkeleyLibrary::TIND::MARC::XMLWriter.new(file)
-          # writer = ::MARC::XMLWriter.new(file)
-          writer.write(tind_record)
-          writer.close
+          BerkeleyLibrary::TIND::MARC::XMLWriter.open(file) do |writer|
+            writer.write(tind_record)
+          end
         end
 
         private

--- a/lib/berkeley_library/tind/mapping/external_tind_field.rb
+++ b/lib/berkeley_library/tind/mapping/external_tind_field.rb
@@ -18,14 +18,15 @@ module BerkeleyLibrary
           include BerkeleyLibrary::Logging
 
           def tind_fields_from_collection_information(hash)
-            return collection_fields(hash) if valid_collection_hash?(hash)
+            raise ArgumentError, 'Collection parameters are incorrect.' unless valid_collection_hash?(hash)
 
-            logger.warn('Collection parameters are incorrect, please check.')
-            []
+            collection_fields(hash)
           end
 
           def tind_mms_id_fields(mms_id)
-            mms_id ? mms_id_fields(mms_id) : []
+            raise ArgumentError, 'mms_id is nil' unless mms_id
+
+            mms_id_fields(mms_id)
           end
 
           private

--- a/lib/berkeley_library/tind/mapping/external_tind_field.rb
+++ b/lib/berkeley_library/tind/mapping/external_tind_field.rb
@@ -24,11 +24,8 @@ module BerkeleyLibrary
             []
           end
 
-          def tind_fields_from_alma_id(mms_id, alma_id)
-            return mms_id_fields(mms_id) if mms_id
-
-            logger.warn("#{alma_id} has no Control Field 001")
-            []
+          def tind_mms_id_fields(mms_id)
+            mms_id ? mms_id_fields(mms_id) : []
           end
 
           private

--- a/lib/berkeley_library/tind/mapping/field_catalog.rb
+++ b/lib/berkeley_library/tind/mapping/field_catalog.rb
@@ -115,14 +115,22 @@ module BerkeleyLibrary
         # If tag is listed in csv_mapper.one_occurrence_tags
         # Check pre_existed field of this tag
         # make sure to keep the first datafield for an one_occurrence_tag defined in csv mapping file
+        # def no_pre_existed_field?(tag)
+        #   # no one-occurrence defined in csv
+        #   return true unless one_occurrence_tags.include? tag
+
+        #   # Checking the exsisting regular fields include the one-occurrence field defined in the csv
+        #   return false if @alma_field_tags.compact.include? tag
+
+        #   true
+        # end
+
         def no_pre_existed_field?(tag)
           # no one-occurrence defined in csv
           return true unless one_occurrence_tags.include? tag
 
           # Checking the exsisting regular fields include the one-occurrence field defined in the csv
-          return false if @alma_field_tags.compact.include? tag
-
-          true
+          !(@alma_field_tags.compact.include? tag)
         end
 
         def alma_mms_id

--- a/lib/berkeley_library/tind/mapping/field_catalog_util.rb
+++ b/lib/berkeley_library/tind/mapping/field_catalog_util.rb
@@ -16,6 +16,7 @@ module BerkeleyLibrary
             next unless tag
 
             rule = rules[Util.tag_symbol(tag)]
+
             assing_field(rule, f, datafields_hash)
           end
 

--- a/lib/berkeley_library/tind/module_info.rb
+++ b/lib/berkeley_library/tind/module_info.rb
@@ -7,7 +7,7 @@ module BerkeleyLibrary
       SUMMARY = 'TIND DA utilities for the UC Berkeley Library'.freeze
       DESCRIPTION = 'UC Berkeley Library utility gem for working with the TIND DA digital archive.'.freeze
       LICENSE = 'MIT'.freeze
-      VERSION = '0.5.1'.freeze
+      VERSION = '0.6.0'.freeze
       HOMEPAGE = 'https://github.com/BerkeleyLibrary/tind'.freeze
     end
   end

--- a/lib/berkeley_library/util/files.rb
+++ b/lib/berkeley_library/util/files.rb
@@ -30,8 +30,7 @@ module BerkeleyLibrary
       #
       # @param obj [Object] the object that might be an IO
       def writer_like?(obj)
-        # TODO: is it possible/desirable to loosen this? how strict is libxml2?
-        obj.is_a?(IO) || obj.is_a?(StringIO)
+        obj.respond_to?(:write) && obj.respond_to?(:close)
       end
 
     end

--- a/spec/berkeley_library/tind/mapping/alma_base_spec.rb
+++ b/spec/berkeley_library/tind/mapping/alma_base_spec.rb
@@ -52,7 +52,7 @@ module BerkeleyLibrary
         describe '# base_save' do
           it 'save tind record' do
             dummy_obj.base_save('C084093187', qualified_alm_record, save_to_file)
-            expect(File.open(save_to_file.path).readlines[0]).to eq "<?xml version='1.0'?>\n"
+            expect(File.open(save_to_file.path).readlines[0]).to eq "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
           end
         end
 

--- a/spec/berkeley_library/tind/mapping/alma_base_spec.rb
+++ b/spec/berkeley_library/tind/mapping/alma_base_spec.rb
@@ -20,32 +20,17 @@ module BerkeleyLibrary
 
         describe '# base_tind_record' do
           it 'input a qualified Alma record - return a tind record' do
-            allow(dummy_obj).to receive(:qualified?).with(qualified_alm_record, 'C084093187').and_return(true)
             allow(dummy_obj).to receive(:tind_record).with('C084093187', qualified_alm_record, []).and_return(::MARC::Record.new)
             expect(dummy_obj.base_tind_record('C084093187', [], qualified_alm_record)).to be_a ::MARC::Record
           end
 
           it 'input an unqualified Alma record - return nil' do
-            allow(dummy_obj).to receive(:qualified?).with(alma_record, 'C084093187').and_return(false)
-            expect(dummy_obj.base_tind_record('C084093187', [], alma_record)).to eq nil
-          end
-
-          it 'no input Alma record but having a qualified Alma record from id - return tind record' do
-            allow(dummy_obj).to receive(:qualified?).with(alma_record, 'C084093187').and_return(true)
-            allow(dummy_obj).to receive(:tind_record).with('C084093187', alma_record, []).and_return(::MARC::Record.new)
-            allow(dummy_obj).to receive(:alma_record_from).with('C084093187').and_return(::MARC::Record.new)
-            expect(dummy_obj.base_tind_record('C084093187', [])).to be_a ::MARC::Record
-          end
-
-          it 'no input Alma record and having an unqualified Alma record from id - return nil' do
-            allow(dummy_obj).to receive(:qualified?).with(alma_record, 'C084093187').and_return(false)
-            allow(dummy_obj).to receive(:alma_record_from).with('C084093187').and_return(::MARC::Record.new)
-            expect(dummy_obj.base_tind_record('C084093187', [])).to eq nil
+            expect { dummy_obj.base_tind_record('C084093187', [], un_qualified_alm_record) }.to raise_error(ArgumentError)
           end
 
           it 'no input Alma record with a nil (record) from id  - return nil' do
             allow(dummy_obj).to receive(:alma_record_from).with('C084093187').and_return(nil)
-            expect(dummy_obj.base_tind_record('C084093187', [])).to eq nil
+            expect { dummy_obj.base_tind_record('C084093187', []) }.to raise_error(ArgumentError)
           end
         end
 
@@ -53,16 +38,6 @@ module BerkeleyLibrary
           it 'save tind record' do
             dummy_obj.base_save('C084093187', qualified_alm_record, save_to_file)
             expect(File.open(save_to_file.path).readlines[0]).to eq "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-          end
-        end
-
-        describe '# qualified?' do
-          it 'qualified Alma record, return true' do
-            expect(dummy_obj.send(:qualified?, qualified_alm_record, 'C084093187')).to be true
-          end
-
-          it 'unqualified Alma record, return false' do
-            expect(dummy_obj.send(:qualified?, un_qualified_alm_record, 'C084093187')).to be false
           end
         end
 

--- a/spec/berkeley_library/tind/mapping/alma_base_spec.rb
+++ b/spec/berkeley_library/tind/mapping/alma_base_spec.rb
@@ -124,12 +124,12 @@ module BerkeleyLibrary
           end
 
           it 'get derived fields without 035' do
-            expect(dummy_obj.send(:derived_tind_fields, id, id).map(&:tag)).to eq tags
+            expect(dummy_obj.send(:derived_tind_fields, id).map(&:tag)).to eq tags
           end
 
           it 'get derived fields with 035' do
             BerkeleyLibrary::TIND::Mapping::AlmaBase.is_035_from_mms_id = true
-            expect(dummy_obj.send(:derived_tind_fields, id, id).map(&:tag)).to eq tags_with_035
+            expect(dummy_obj.send(:derived_tind_fields, id).map(&:tag)).to eq tags_with_035
           end
 
         end

--- a/spec/berkeley_library/tind/mapping/alma_single_tind_spec.rb
+++ b/spec/berkeley_library/tind/mapping/alma_single_tind_spec.rb
@@ -78,21 +78,7 @@ module BerkeleyLibrary
             mapper = BerkeleyLibrary::TIND::Mapping::AlmaSingleTIND.new
             url = "https://digitalassets.lib.berkeley.edu/pre1912ChineseMaterials/ucb/ready/#{id}/#{id}_v001_0064.jpg"
             fft = BerkeleyLibrary::TIND::Mapping::TindField.f_fft(url, 'v001_0064')
-            tind_record = mapper.record(id, [fft])
-
-            expect(tind_record).to be_a(::MARC::Record)
-            expect(tind_record['FFT']).to eq(fft)
-
-            expect(tind_record['901']).to be_nil
-            expect(tind_record['035']).to be_nil
-
-            alma_record = ::MARC::XMLReader.read(StringIO.new(marc_xml)).first
-            sf_245a_expected = alma_record.spec('245$a{$6=\880-02}').first
-            sf_245_value_expected = sf_245a_expected.value.sub(/[^[:alnum:]]+$/, '')
-
-            sf_245a_actual = tind_record.spec('245$a{$6=\880-02}').first
-            sf_245a_value_actual = sf_245a_actual.value
-            expect(sf_245a_value_actual).to eq(sf_245_value_expected)
+            expect { mapper.record(id, [fft]) }.to raise_error(ArgumentError)
           end
         end
       end

--- a/spec/berkeley_library/tind/mapping/alma_single_tind_spec.rb
+++ b/spec/berkeley_library/tind/mapping/alma_single_tind_spec.rb
@@ -7,6 +7,9 @@ module BerkeleyLibrary
         let(:additona_245_field) { [Util.datafield('245', [' ', ' '], [Util.subfield('a', 'fake 245 a')])] }
         let(:marc_obj) { (::MARC::Record.new).append(additona_245_field) }
 
+        before { BerkeleyLibrary::Alma::Config.default! }
+        after { BerkeleyLibrary::Alma::Config.send(:clear!) }
+
         it ' get tind record' do
           alma_single_tind = BerkeleyLibrary::TIND::Mapping::AlmaSingleTIND.new
 
@@ -14,6 +17,84 @@ module BerkeleyLibrary
           expect(alma_single_tind.record('991085821143406532', additona_245_field)).to be marc_obj
         end
 
+        describe 'TIND record mapping' do
+          let(:coll_param_hash) do
+            {
+              '336' => ['Image'],
+              '852' => ['East Asian Library'],
+              '980' => ['pre_1912'],
+              '982' => ['Pre 1912 Chinese Materials - short name', 'Pre 1912 Chinese Materials - long name'],
+              '991' => []
+            }
+          end
+
+          let(:id) { '991032333019706532' }
+          let(:marc_url) { BerkeleyLibrary::Alma::RecordId.parse(id).marc_uri.to_s }
+          let(:logger) { BerkeleyLibrary::Logging.logger }
+
+          before do
+            AlmaBase.collection_parameter_hash = coll_param_hash
+            AlmaBase.is_035_from_mms_id = true
+          end
+
+          after do
+            AlmaBase.collection_parameter_hash = nil
+            AlmaBase.is_035_from_mms_id = false
+          end
+
+          it 'transforms a record' do
+            marc_xml = File.read('spec/data/mapping/991032333019706532-sru.xml')
+            stub_request(:get, marc_url).to_return(body: marc_xml)
+
+            expect(logger).not_to receive(:warn)
+
+            mapper = BerkeleyLibrary::TIND::Mapping::AlmaSingleTIND.new
+            url = "https://digitalassets.lib.berkeley.edu/pre1912ChineseMaterials/ucb/ready/#{id}/#{id}_v001_0064.jpg"
+            fft = BerkeleyLibrary::TIND::Mapping::TindField.f_fft(url, 'v001_0064')
+            tind_record = mapper.record(id, [fft])
+
+            expect(tind_record).to be_a(::MARC::Record)
+            expect(tind_record['FFT']).to eq(fft)
+
+            expect(tind_record['901']['m']).to eq(id)
+            expect(tind_record['035']['a']).to eq("(pre_1912)#{id}")
+
+            alma_record = ::MARC::XMLReader.read(StringIO.new(marc_xml)).first
+            sf_245a_expected = alma_record.spec('245$a{$6=\880-02}').first
+            sf_245_value_expected = sf_245a_expected.value.sub(/[^[:alnum:]]+$/, '')
+
+            sf_245a_actual = tind_record.spec('245$a{$6=\880-02}').first
+            sf_245a_value_actual = sf_245a_actual.value
+            expect(sf_245a_value_actual).to eq(sf_245_value_expected)
+          end
+
+          it 'handles pathological records without an 001 control field' do
+            marc_xml = File.read('spec/data/mapping/991032333019706532-sru.xml')
+              .sub('<controlfield tag="001">991032333019706532</controlfield>', '')
+            stub_request(:get, marc_url).to_return(body: marc_xml)
+
+            expect(logger).to receive(:warn).with("#{id} has no Control Field 001")
+
+            mapper = BerkeleyLibrary::TIND::Mapping::AlmaSingleTIND.new
+            url = "https://digitalassets.lib.berkeley.edu/pre1912ChineseMaterials/ucb/ready/#{id}/#{id}_v001_0064.jpg"
+            fft = BerkeleyLibrary::TIND::Mapping::TindField.f_fft(url, 'v001_0064')
+            tind_record = mapper.record(id, [fft])
+
+            expect(tind_record).to be_a(::MARC::Record)
+            expect(tind_record['FFT']).to eq(fft)
+
+            expect(tind_record['901']).to be_nil
+            expect(tind_record['035']).to be_nil
+
+            alma_record = ::MARC::XMLReader.read(StringIO.new(marc_xml)).first
+            sf_245a_expected = alma_record.spec('245$a{$6=\880-02}').first
+            sf_245_value_expected = sf_245a_expected.value.sub(/[^[:alnum:]]+$/, '')
+
+            sf_245a_actual = tind_record.spec('245$a{$6=\880-02}').first
+            sf_245a_value_actual = sf_245a_actual.value
+            expect(sf_245a_value_actual).to eq(sf_245_value_expected)
+          end
+        end
       end
     end
   end

--- a/spec/berkeley_library/tind/mapping/alma_spec.rb
+++ b/spec/berkeley_library/tind/mapping/alma_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+module BerkeleyLibrary
+  module TIND
+    module Mapping
+      describe Alma do
+        let(:alma_obj) { Alma.new('spec/data/mapping/record.xml') }
+
+        it 'control field value' do
+          expect(alma_obj.control_field.tag).to eq '008'
+        end
+
+        it 'control field value' do
+          expect(alma_obj.control_field.tag).to eq '008'
+        end
+
+        it '880 field' do
+          expect(alma_obj.field_880('245-01/$1')['6']).to eq '245-01/$1'
+        end
+
+        it 'regular field' do
+          expect(alma_obj.field('245').tag).to eq '245'
+        end
+
+      end
+    end
+  end
+end

--- a/spec/berkeley_library/tind/mapping/external_tind_field_spec.rb
+++ b/spec/berkeley_library/tind/mapping/external_tind_field_spec.rb
@@ -30,12 +30,12 @@ module BerkeleyLibrary
 
           it 'get derived tind fields from alma id' do
             alma_id = '991085821143406532'
-            expect(ExternalTindField.tind_fields_from_alma_id(alma_id, alma_id).map(&:tag)).to eq output_alma_tags
+            expect(ExternalTindField.tind_mms_id_fields(alma_id).map(&:tag)).to eq output_alma_tags
           end
 
           it 'get empty tind fields from a nil alma id' do
             alma_id = nil
-            expect(ExternalTindField.tind_fields_from_alma_id(alma_id, alma_id).map(&:tag)).to eq []
+            expect(ExternalTindField.tind_mms_id_fields(alma_id).map(&:tag)).to eq []
 
           end
         end

--- a/spec/berkeley_library/tind/mapping/external_tind_field_spec.rb
+++ b/spec/berkeley_library/tind/mapping/external_tind_field_spec.rb
@@ -21,7 +21,7 @@ module BerkeleyLibrary
           end
 
           it 'get [] derived from empty collection information' do
-            expect(ExternalTindField.tind_fields_from_collection_information(bad_hash).map(&:tag)).to eq []
+            expect { ExternalTindField.tind_fields_from_collection_information(bad_hash).map(&:tag) }.to raise_error(ArgumentError)
           end
         end
 
@@ -35,8 +35,7 @@ module BerkeleyLibrary
 
           it 'get empty tind fields from a nil alma id' do
             alma_id = nil
-            expect(ExternalTindField.tind_mms_id_fields(alma_id).map(&:tag)).to eq []
-
+            expect { ExternalTindField.tind_mms_id_fields(alma_id).map(&:tag) }.to raise_error(ArgumentError)
           end
         end
 

--- a/spec/berkeley_library/tind/mapping/field_catalog_util_spec.rb
+++ b/spec/berkeley_library/tind/mapping/field_catalog_util_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+module BerkeleyLibrary
+  module TIND
+    module Mapping
+      describe FieldCatalogUtil do
+        include Util
+        include Misc
+        include FieldCatalogUtil
+        include TindSubfieldUtil
+        include CsvMapper
+
+        let(:qualified_alma_obj) { Alma.new('spec/data/mapping/record.xml') }
+        let(:qualified_alm_record) { qualified_alma_obj.record }
+        let(:regular_field_tags) do
+          %w[255
+             507
+             245
+             246
+             260
+             300
+             490
+             630
+             650
+             700
+             710
+             264]
+        end
+
+        let(:normal) { %w[255 245 246 260 300 300 490 630 650 650 700 710] }
+        let(:pre_tag) { ['264', '264'] }
+        let(:pre_tag_subfield) { ['507'] }
+
+        it 'excluding fast subject field' do
+          fields = qualified_alm_record.fields.select { |f| ['650', '245'].include? f.tag }
+          expect(fields.length).to eq 3
+
+          final_fields = exluding_fields_with_fast_subject(fields)
+          expect(final_fields.length).to eq 2
+          expect(final_fields[0].tag).to eq '245'
+
+        end
+
+        it 'preparing field group' do
+          fields = qualified_alm_record.fields.select { |f| regular_field_tags.include? f.tag }
+          expect(fields.length).to eq 15
+
+          group = prepare_group(fields)
+          expect(group[:normal].map(&:tag)).to eq normal
+          expect(group[:pre_tag].map(&:tag)).to eq pre_tag
+          expect(group[:pre_tag_subfield].map(&:tag)).to eq pre_tag_subfield
+        end
+
+      end
+    end
+  end
+end

--- a/spec/berkeley_library/tind/mapping/match_tind_field_spec.rb
+++ b/spec/berkeley_library/tind/mapping/match_tind_field_spec.rb
@@ -15,7 +15,7 @@ module BerkeleyLibrary
         let(:no_880_matching_count) { 4 }
 
         it 'get 880 un-matched fields' do
-          puts tind_marc.send(:un_matched_fields_880, data_fields, '991032577079706532').inspect
+          # puts tind_marc.send(:un_matched_fields_880, data_fields, '991032577079706532').inspect
           expect(tind_marc.send(:un_matched_fields_880, data_fields, '991032577079706532').length).to eq no_880_matching_count
         end
 

--- a/spec/berkeley_library/tind/marc/xml_writer_spec.rb
+++ b/spec/berkeley_library/tind/marc/xml_writer_spec.rb
@@ -187,6 +187,30 @@ module BerkeleyLibrary
               end
             end
           end
+
+          it 'writes to a Tempfile object' do
+            Dir.mktmpdir(File.basename(__FILE__, '.rb')) do |dir|
+              out = Tempfile.new(File.join(dir, 'marc.xml'))
+              begin
+                # noinspection RubyMismatchedArgumentType
+                w = XMLWriter.new(out)
+                w.write(record)
+                w.close
+
+                expected = File.open(input_path) { |f| Nokogiri::XML(f) }
+                actual = File.open(out.path) { |f| Nokogiri::XML(f) }
+              ensure
+                out.close
+                out.unlink
+              end
+
+              aggregate_failures do
+                EquivalentXml.equivalent?(expected, actual) do |n1, n2, result|
+                  expect(n2.to_s).to eq(n1.to_s) unless result
+                end
+              end
+            end
+          end
         end
       end
     end

--- a/spec/data/mapping/991032333019706532-sru.xml
+++ b/spec/data/mapping/991032333019706532-sru.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+  <version>1.2</version>
+  <numberOfRecords>1</numberOfRecords>
+  <records>
+    <record>
+      <recordSchema>marcxml</recordSchema>
+      <recordPacking>xml</recordPacking>
+      <recordData>
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <leader>02731cam a2200421Ii 4500</leader>
+          <controlfield tag="001">991032333019706532</controlfield>
+          <controlfield tag="005">20211019014713.0</controlfield>
+          <controlfield tag="008">000110s1777    cc            000 0 chi d</controlfield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(CUY)UCB-b109259853-01ucs_ber</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(OCoLC)43247971</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(OCoLC)ocm43247971</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="035">
+            <subfield code="a">(EXLNZ-01UCS_NETWORK)9913298571106531</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="040">
+            <subfield code="a">CUY</subfield>
+            <subfield code="b">eng</subfield>
+            <subfield code="e">cgcrb</subfield>
+            <subfield code="c">CUY</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">OCLCF</subfield>
+            <subfield code="d">OCLCQ</subfield>
+            <subfield code="d">OCLCO</subfield>
+            <subfield code="d">OCLCQ</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="049">
+            <subfield code="a">CUYM</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="100">
+            <subfield code="6">880-01</subfield>
+            <subfield code="a">Yue, Ke,</subfield>
+            <subfield code="d">1183-1234,</subfield>
+            <subfield code="e">author</subfield>
+          </datafield>
+          <datafield ind1="1" ind2=" " tag="880">
+            <subfield code="6">100-01</subfield>
+            <subfield code="a">岳珂,</subfield>
+            <subfield code="d">1183-1234,</subfield>
+            <subfield code="e">author</subfield>
+          </datafield>
+          <datafield ind1="1" ind2="0" tag="245">
+            <subfield code="6">880-02</subfield>
+            <subfield code="a">Bao zhen zhai fa shu zan :</subfield>
+            <subfield code="b">28 juan /</subfield>
+            <subfield code="c">Yue Ke zhuan.</subfield>
+          </datafield>
+          <datafield ind1="1" ind2="0" tag="880">
+            <subfield code="6">245-02</subfield>
+            <subfield code="a">寶真齋法書贊 :</subfield>
+            <subfield code="b">二十八卷 /</subfield>
+            <subfield code="c">岳珂撰.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="250">
+            <subfield code="6">880-03</subfield>
+            <subfield code="a">Wu ying dian ju zhen ban.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="880">
+            <subfield code="6">250-03</subfield>
+            <subfield code="a">武英殿聚珍版.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="1" tag="264">
+            <subfield code="6">880-04</subfield>
+            <subfield code="a">[Fujian :</subfield>
+            <subfield code="b">Fujian bu zheng si,</subfield>
+            <subfield code="c">Qing qian long 42 nian [1777]</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="1" tag="880">
+            <subfield code="6">264-04</subfield>
+            <subfield code="a">[福建 :</subfield>
+            <subfield code="b">福建佈政司,</subfield>
+            <subfield code="c">清乾隆42年[1777]</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="300">
+            <subfield code="a">8 volumes (double leaves) in case ;</subfield>
+            <subfield code="c">23 cm</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="336">
+            <subfield code="a">text</subfield>
+            <subfield code="b">txt</subfield>
+            <subfield code="2">rdacontent</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="337">
+            <subfield code="a">unmediated</subfield>
+            <subfield code="b">n</subfield>
+            <subfield code="2">rdamedia</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="338">
+            <subfield code="a">volume</subfield>
+            <subfield code="b">nc</subfield>
+            <subfield code="2">rdacarrier</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="500">
+            <subfield code="6">880-05</subfield>
+            <subfield code="a">Engraved (early 19th cent.?) from Wu ying dian ju zhen ban ed.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="880">
+            <subfield code="6">500-05</subfield>
+            <subfield code="a">Engraved (early 19th cent.?) from 武英殿聚珍版 ed.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="650">
+            <subfield code="6">880-06</subfield>
+            <subfield code="a">Calligraphy, Chinese.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="880">
+            <subfield code="6">650-06</subfield>
+            <subfield code="a">子部</subfield>
+            <subfield code="x">藝術類</subfield>
+            <subfield code="x">書畫之属</subfield>
+            <subfield code="2">sk</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="7" tag="650">
+            <subfield code="a">Calligraphy, Chinese.</subfield>
+            <subfield code="2">fast</subfield>
+            <subfield code="0">(OCoLC)fst00844390</subfield>
+          </datafield>
+          <datafield ind1="0" ind2="8" tag="776">
+            <subfield code="i">Online version:</subfield>
+            <subfield code="t">Bao zhen zhai fa shu zan.</subfield>
+            <subfield code="b">Wu ying dian ju zhen ban.</subfield>
+            <subfield code="d">[China : s.n., between 1774 and 1912]]</subfield>
+            <subfield code="w">(OCoLC)698022544</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="880">
+            <subfield code="6">500-00</subfield>
+            <subfield code="a">"玄","弘"字缺末笔(卷八葉八飯，葉九正; 卷七葉十二反),"琰","顒"字不避諱(卷七頁葉二十四正, 卷二十首葉反, 卷十葉十三反)</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="880">
+            <subfield code="6">500-00</subfield>
+            <subfield code="a">半葉框19.5x12.6 公分,9行21字小字雙行字數同,四周雙邊, 白口, 單黑魚尾,版心上鐫書名中鐫卷序及頁碼下鐫校者姓名.目录下鐫"武英殿聚珍版"</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="880">
+            <subfield code="6">500-00</subfield>
+            <subfield code="a">首有乾隆甲午仲夏 [1774]“御製題武英殿聚珍版十韻 有序”.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="880">
+            <subfield code="6">500-00</subfield>
+            <subfield code="a">是書特征與杨之峰作"《武英殿聚珍版丛书》零种的鉴定"一文中關於福建本的描述相符合, 出版年据马月华作"略论福建本'外聚珍'"中“福建省“ 外聚珍” 五次印本目录总表”.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="880">
+            <subfield code="6">561-00</subfield>
+            <subfield code="a">本書各冊封面有手題書名及卷序以及"陶孝邈瀏覽一次",首冊另有手題“戊辰仲春山農為紫藤舘主人題面”並鈐有“山子”朱文方印. 第八冊扉頁手題“此書為娛圍生舊藏貽其甥趙蘭士題簽者為孫子杉農瀏覽者為陶子紫畛 庚午熾暑無聊題卷画”. 鈐印：“今関天彭之印”</subfield>
+            <subfield code="5">CU-EAST</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="4" tag="880">
+            <subfield code="6">510-00</subfield>
+            <subfield code="a">图书馆学刊,</subfield>
+            <subfield code="c">2009(01) : 89-91.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="4" tag="880">
+            <subfield code="6">510-00</subfield>
+            <subfield code="a">中国典籍与文化,</subfield>
+            <subfield code="c">2010(02): 73-85.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="955">
+            <subfield code="a">eaek</subfield>
+            <subfield code="9">local</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="955">
+            <subfield code="a">20211019</subfield>
+            <subfield code="b">eahl</subfield>
+            <subfield code="9">local</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="955">
+            <subfield code="a">eaek</subfield>
+            <subfield code="9">local</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="996">
+            <subfield code="e">GLADN117908085</subfield>
+            <subfield code="9">local</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="996">
+            <subfield code="a">b109259853</subfield>
+            <subfield code="b">Updated: 12-21-20</subfield>
+            <subfield code="c">Created: 03-16-09</subfield>
+            <subfield code="d">CatDate: 08-25-11</subfield>
+            <subfield code="9">local</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="AVA">
+            <subfield code="0">991032333019706532</subfield>
+            <subfield code="8">22670862550006532</subfield>
+            <subfield code="a">01UCS_BER</subfield>
+            <subfield code="b">NRLF</subfield>
+            <subfield code="c">NRLF (UCB)</subfield>
+            <subfield code="d">6138.7712</subfield>
+            <subfield code="e">available</subfield>
+            <subfield code="f">1</subfield>
+            <subfield code="g">0</subfield>
+            <subfield code="i">UCB_Campus</subfield>
+            <subfield code="j">nbea</subfield>
+            <subfield code="k">0</subfield>
+            <subfield code="p">1</subfield>
+            <subfield code="q">Northern Regional Library Facility</subfield>
+            <subfield code="t">v. 1-8</subfield>
+          </datafield>
+        </record>
+      </recordData>
+      <recordIdentifier>991032333019706532</recordIdentifier>
+      <recordPosition>1</recordPosition>
+    </record>
+  </records>
+  <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+    <xb:exact>true</xb:exact>
+    <xb:responseDate>2022-04-04T10:17:17-0700</xb:responseDate>
+  </extraResponseData>
+</searchRetrieveResponse>


### PR DESCRIPTION
- Move Alma configuration out of `AlmaBase` into scripts
- Add README section on Alma configuration
- Misc. code cleanup:
  - remove unnecessary explicit module references when we're already inside the namespace (`BerkeleyLibrary::TIND::Mapping::AlmaBase.collection_parameter_hash` ⇒ `AlmaBase.collection_parameter_hash`, etc.)
  - rename `ExternalTindField.tind_fields_from_alma_id` to `tind_mms_id_fields`, and remove the second `id` parameter which was only used to log a warning if `mms_id` was nil (warning is now logged from `AlmaBase.tind_record` instead)
- Update changelog and gem version