### PR TITLE
upgrade alma gem and prep for 0.8.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # 0.8.0 (2025-07-28)
 
-- Upgrade to latest version of berkeley_library-tind
+- Upgrade to latest version of berkeley_library-alma.
 
 # 0.7.3 (2025-07-22)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,20 @@
+# 0.8.0 (2025-07-28)
+
+- Upgrade to latest version of berkeley_library-tind
+
+# 0.7.3 (2025-07-22)
+
+- Using ruby 3.3, build tests 3.4 as well. Additional mapping for Alma 561 to Tind 561 (no translation needed).
+
+# 0.7.2 (2023-10-23)
+
+- Updates the logger
+
+# 0.7.1 (2023-01-19)
+
+- Pin rubyzip to < 3.0 to avoid incompatibilities
+- add workaround for sparklemotion/nokogiri#2773 (#10)
+
 # 0.7.0 (2022-10-26)
 
 - Preserves subfield order insofar as possible when mapping Alma records to TIND.

--- a/berkeley_library-tind.gemspec
+++ b/berkeley_library-tind.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ruby_version
 
-  spec.add_dependency 'berkeley_library-alma', '~> 0.0.1'
+  spec.add_dependency 'berkeley_library-alma', '~> 0.1.0'
   spec.add_dependency 'berkeley_library-logging', '~> 0.2'
   spec.add_dependency 'berkeley_library-marc', '~> 0.3.0', '>= 0.3.1'
   spec.add_dependency 'berkeley_library-util', '~> 0.1', '>= 0.1.2'

--- a/lib/berkeley_library/tind/module_info.rb
+++ b/lib/berkeley_library/tind/module_info.rb
@@ -7,7 +7,7 @@ module BerkeleyLibrary
       SUMMARY = 'TIND DA utilities for the UC Berkeley Library'.freeze
       DESCRIPTION = 'UC Berkeley Library utility gem for working with the TIND DA digital archive.'.freeze
       LICENSE = 'MIT'.freeze
-      VERSION = '0.7.3'.freeze
+      VERSION = '0.8.0'.freeze
       HOMEPAGE = 'https://github.com/BerkeleyLibrary/tind'.freeze
     end
   end


### PR DESCRIPTION
we missed a semver update of the alma gem last week when upgrading this gem.